### PR TITLE
Fixed for ArcGIS Pro

### DIFF
--- a/operational_graphics/toolboxes/scripts/NumberFeatures.py
+++ b/operational_graphics/toolboxes/scripts/NumberFeatures.py
@@ -42,16 +42,16 @@ def labelFeatures(layer, field):
         layer.showLabels = True
         arcpy.RefreshActiveView()
 
-def findLayerByName(layerName, gisVersion):
-    #UPDATE
-    if gisVersion == "1.0": #Pro:
-          for layer in maplist.listLayers():
+def findLayerByName(layerName):
+    try: # ArcGIS Pro
+        from arcpy import mp
+        for layer in maplist.listLayers():
             if layer.name == layerName:
                 arcpy.AddMessage("Found matching layer [" + layer.name + "]")
                 return layer
             else:
                 arcpy.AddMessage("Incorrect layer: [" + layer.name + "]")
-    else:
+    except ImportError: # ArcMap
         for layer in arcpy.mapping.ListLayers(mxd):
             if layer.name == layerName:
                 arcpy.AddMessage("Found matching layer [" + layer.name + "]")
@@ -72,8 +72,6 @@ try:
     arcpy.AddMessage("Shape type: " + str(areaGeom))
     if (descArea.shapeType != "Polygon"):
         raise Exception("ERROR: The area to number must be a polygon.")
-
-    gisVersion = arcpy.GetInstallInfo()["Version"]
 
     mxd, df, aprx, mp = None, None, None, None
     try: # ArcGIS Pro
@@ -149,7 +147,7 @@ try:
         targetLayerName = os.path.basename(outputFeatureClass)
 
     # Get and label the output feature
-    layer = findLayerByName(targetLayerName, gisVersion)
+    layer = findLayerByName(targetLayerName)
     if(layer):
         labelFeatures(layer, numberingField)
 

--- a/operational_graphics/toolboxes/scripts/NumberFeatures.py
+++ b/operational_graphics/toolboxes/scripts/NumberFeatures.py
@@ -76,14 +76,14 @@ try:
     gisVersion = arcpy.GetInstallInfo()["Version"]
 
     mxd, df, aprx, mp = None, None, None, None
-    if gisVersion == "1.0": #Pro:
+    try: # ArcGIS Pro
         from arcpy import mp
         aprx = arcpy.mp.ArcGISProject("CURRENT")
         maplist = aprx.listMaps()[0]
         for lyr in maplist.listLayers():
             if lyr.name == pointFeatureName:
                 layerExists = True
-    else:
+    except ImportError: # ArcMap
         from arcpy import mapping
         mxd = arcpy.mapping.MapDocument('CURRENT')
         for lyr in arcpy.mapping.ListLayers(mxd):
@@ -153,5 +153,5 @@ try:
     if(layer):
         labelFeatures(layer, numberingField)
 
-except Exception, ex:
+except (Exception) as ex:
     arcpy.AddError(ex)


### PR DESCRIPTION
1. The existing code uses Python 2.x try/except syntax, which cannot work in ArcGIS Pro because of Python 3.x.

2. The existing code would only work for ArcGIS Pro 1.0, not 1.1. The new code uses a different way of checking that should work for any ArcGIS Pro version.