### PR TITLE
fixed pathing issue with hlz test geodatabase

### DIFF
--- a/utils/test/capability_tests/HLZTouchdownPointsTestCase.py
+++ b/utils/test/capability_tests/HLZTouchdownPointsTestCase.py
@@ -81,7 +81,7 @@ class HLZTouchdownPoints(unittest.TestCase):
         self.testDataGeodatabase = os.path.join(self.testDataFolderPath, r"test_hlz_tools.gdb")
         
         # Download the test data from arcgis.com
-        self.testDataFolderPath = DataDownload.runDataDownload(self.testDataFolderPath,
+        self.testDataFolderPath = DataDownload.runDataDownload(Configuration.capabilityPath,
                                                                os.path.basename(self.testDataGeodatabase),
                                                                self.dataDownloadURL)
 


### PR DESCRIPTION
This was causing the data folder path to be double-loaded when the HLZ tests were run causing errors like...


`
test_Choose_Field_Value_Script_Tool_Desktop (capability_tests.HLZTouchdownPointsTestCase.HLZTouchdownPoints)Traceback (most recent call last):
  File "D:\GitHub\solutions-geoprocessing-toolbox\utils\test\capability_tests\HLZTouchdownPointsTestCase.py", line 104, in setUp
    self.inputSlope])
  File "D:\GitHub\solutions-geoprocessing-toolbox\utils\test\UnitTestUtilities.py", line 175, in checkGeoObjects
    desc = arcpy.Describe(object2Check)
  File "C:\Program Files (x86)\ArcGIS\Desktop10.4\ArcPy\arcpy\__init__.py", line 1253, in Describe
    return gp.describe(value)
  File "C:\Program Files (x86)\ArcGIS\Desktop10.4\ArcPy\arcpy\geoprocessing\_base.py", line 376, in describe
    self._gp.Describe(*gp_fixargs(args, True)))
IOError: "D:\GitHub\solutions-geoprocessing-toolbox\utils\test\capability_tests\data\test_hlz_tools.gdb" does not exist
`