### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ The ArcGIS Solutions Geoprocessing Toolbox is a collection of models, scripts, a
 ![Image of the toolbox](./img/solutions-geoprocessing-toolbox_screenshot_14APR2016_824x400.png)
 
 
-###Repository Owner: [Matt](https://github.com/mfunk)
+### Repository Owner: [Matt](https://github.com/mfunk)
 
 * Merge Pull Requests
 * Creates Releases and Tags
 * Manages Milestones
 * Manages and Assigns Issues
 
-###Secondary: [Chris](https://github.com/csmoore)
+### Secondary: [Chris](https://github.com/csmoore)
 
 * Backup when the Owner is away
 

--- a/utils/test/Readme.md
+++ b/utils/test/Readme.md
@@ -1,6 +1,6 @@
-#Running tests for solutions-geoprocessing-toolbox
+# Running tests for solutions-geoprocessing-toolbox
 
-##Sections
+## Sections
 * [Introduction](#introduction)
 * [Requirements](#requirements)
 	* [For ArcGIS Pro](#for-arcgis-pro)
@@ -9,19 +9,19 @@
 * [Log files](#log-files)
 * [Reporting errors as Issues](#reporting-errors-as-issues)
 
-##Introduction
+## Introduction
 The unittests in this section of the repository are designed to test the geoprocessing tools contained within to make sure they are running consistently under different conditions. Automated testing, unittests are one type, help reduce the amount of time necessary to find defects or confirm their success. An automated test can run all of the tools in a significantly shorter amount of time than several people testing the tools manually. This should not be taken as an opportunity to skip other types of testing (ad-hoc, defect verification, template testing, system testing, etc.).
 
-##Requirements
-###For ArcGIS Pro
+## Requirements
+### For ArcGIS Pro
 * ArcGIS Pro 1.1+
 * Python 3.4.1 for ArcGIS Pro
 
-###For ArcGIS Desktkop
+### For ArcGIS Desktkop
 * ArcGIS for Desktop 10.3.1+
 * Python 2.7+
 
-##Running the tests
+## Running the tests
 The goal is to run the test suites for all of the tools against different versions of operating systems and versions of Python/ArcGIS.
 
 1. Check your Python versions. You need to have at least ONE of two required versions listed above.
@@ -30,7 +30,7 @@ The goal is to run the test suites for all of the tools against different versio
 4. Run **TestKickStart.bat**
 5. Check the dialog for results and check the log file created by the tests.
 
-##Log files
+## Log files
 The output from running the tests are stored in the *.\solutions-geoprocessing-toolbox\utils\test\log* folder. The files are named:
 
      SGT_YYYY-Month-DD_HH-MM-SS_seqX.log
@@ -51,7 +51,7 @@ For example:
 
 This log file was created November 5th, 2015 at 8:31:22 AM and was the first log file created at that time.
 
-##Reporting errors as Issues
+## Reporting errors as Issues
 Any errors or problems need to be reported. If they go unmentioned, then they go unfixed. All issues should be logged in the solutions-geoprocessing-repository [Issues](https://github.com/Esri/solutions-geoprocessing-toolbox/issues).
 
 1. First you should check the existing Issues to see if there is one already logged for the issue you found. If you find one that is the same or similar, please add a comment to it with the information in step 4 below.

--- a/utils/test/WritingTests.md
+++ b/utils/test/WritingTests.md
@@ -1,6 +1,6 @@
-#Writing tests for solutions-geoprocessing-toolbox
+# Writing tests for solutions-geoprocessing-toolbox
 
-##Sections
+## Sections
 * [Introduction](#introduction)
 * [The Test Structure](#the-test-structure)
 * [TestKickStart and TestRunner](testkickstart-and-testrunner)
@@ -8,19 +8,19 @@
 * [Test Cases](#test-cases)
 * [Test Data](#test-data)
 
-##Introduction
+## Introduction
 The goal of this document is to give an overview of how the solutions-geoprocessing-toolbox tests are structured and how they are intended to work. This is just an overview. To build new tests, the successful developer will need to review the existing tests as a guide for building their own.
 
-##The Test Structure
+## The Test Structure
 
-###TestKickStart and TestRunner
+### TestKickStart and TestRunner
 These two files, along with some supporting files, start the tests, and determine which platform the tests will run within.
 
 **TestKickStart.bat** is a simple .BAT file to run the tests under both Python 2.7 (ArcGIS Desktop) and Python 3.4 (ArcGIS Pro).
 
 **TestRunner.py** calls the test suites to run.
 
-###Test Suites
+### Test Suites
 Test suites are collections of [Test Cases](#test-cases). There are two major levels of test suites. The top level are test suites for each of the six tool categories: capability, data_management, operational_graphics, patterns, suitability, visibility. 
 
 The test suite files are named **All[category]TestSuite.py**. In each one is the collection the second level of test suites: the toolbox test suites.
@@ -29,30 +29,30 @@ The toolbox test suites are the collection of test cases for each toolbox in the
 
 These are named **[toolbox name]TestSuite.py**. 
 
-###Test Cases
+### Test Cases
 Test cases are the collection of individual tests for a specific tool, or supporting toolset.
 
 They are named **[toolname]TestCase.py**
 
-###Test Data
+### Test Data
 The it is impossible to build a test without some kind of inputs. Some tests generate their own data internally (Check out the ERG tool tests as an example). But most will require some kind of output test data.
 
 * Test data **must** be stored in the *./data* folder. 
 * Keep feature data in a file geodatabase. You should name it like your toolbox.
 * Any file data (CSV, TXT, XLSX, etc.) should be easy to identify which toolbox it belongs to.
 
-##Outline for writing tests
-###1. Make a separate branch from dev
+## Outline for writing tests
+### 1. Make a separate branch from dev
 Use this as a chance to create a feature branch from **dev** which will be merged back in when you are done. THis keeps your work separate from other work and the main **dev** branch.
 
-###2. Get data and run the test manually
+### 2. Get data and run the test manually
 Before you start writing any test code, collect your releasable data. Then manually run the tool or tools with the data. Make sure it works and you are familiar with the tool's operation and the expected results.
 
-###3. Write your test cases
+### 3. Write your test cases
 Use the existing Test Case files as a guide to get started writing your own. The goal is to run the tool to create output that can be tested by the unittest TestCase assert methods [link to assert methods](https://docs.python.org/3/library/unittest.html#unittest.TestCase).
 
-###4. Wire them up to the framework
+### 4. Wire them up to the framework
 Create a Test Suite that calls your Test Case
 Add your Test Suite to the existing All[category]TestSuite.py
 
-###5. Run the test from TestKickStarter.bat
+### 5. Run the test from TestKickStarter.bat


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
