### PR TITLE
Pro 1.4 encode test driver error

### DIFF
--- a/utils/test/TestRunner.py
+++ b/utils/test/TestRunner.py
@@ -77,18 +77,18 @@ def main():
 def logTestResults(result):
     ''' Write the log file '''
     resultHead = resultsHeader(result)
-    print(resultHead.encode("utf-8"))
-    Configuration.Logger.info(resultHead.encode("utf-8"))
+    print(resultHead)
+    Configuration.Logger.info(resultHead)
     
     if len(result.errors) > 0:
         rError = resultsErrors(result)
-        print(rError.encode("utf-8"))
-        Configuration.Logger.error(rError.encode("utf-8"))
+        print(rError)
+        Configuration.Logger.error(rError)
         
     if len(result.failures) > 0:
         rFail = resultsFailures(result)
-        print(rFail.encode("utf-8"))
-        Configuration.Logger.error(rFail.encode("utf-8"))
+        print(rFail)
+        Configuration.Logger.error(rFail)
     Configuration.Logger.info("END OF TEST =========================================\n")
 
     return

--- a/utils/test/incident_analysis_tests/FindPercentChangeTestCase.py
+++ b/utils/test/incident_analysis_tests/FindPercentChangeTestCase.py
@@ -88,7 +88,7 @@ class FindPercentChangeTestCase(unittest.TestCase):
         UnitTestUtilities.deleteScratch(self.incidentScratchGDB)
         
     def test_percent_change(self):
-        '''test_percent_change_pro'''
+        '''test_percent_change'''
         if Configuration.DEBUG == True: print(".....FindPercentChangeTestCase.test_percent_change")
         arcpy.ImportToolbox(self.toolboxUnderTest, self.toolboxUnderTestAlias)
         runToolMessage = "Running tool (Find Percent Change)"
@@ -100,7 +100,7 @@ class FindPercentChangeTestCase(unittest.TestCase):
             arcpy.FindPercentChange_iaTools(self.inputOldIncidents, self.inputAOIFeatures, self.inputNewIncidents, outputFeatures)
         except:
             msg = arcpy.GetMessages(2)
-            self.fail('Exception in FindPercentChange_iaTools for Pro toolbox \n' + msg)
+            self.fail('Exception in FindPercentChange_iaTools toolbox \n' + msg)
         result = arcpy.GetCount_management(outputFeatures)
         count = int(result.getOutput(0))
         self.assertEqual(count, int(10))

--- a/utils/test/incident_analysis_tests/HotSpotsByAreaTestCase.py
+++ b/utils/test/incident_analysis_tests/HotSpotsByAreaTestCase.py
@@ -101,7 +101,7 @@ class HotSpotsByAreaTestCase(unittest.TestCase):
             arcpy.HotSpotsByArea_iaTools(self.inputAOIFeatures, "incidentsLayer", incidentFieldName, outputWorkspace)
         except:
             msg = arcpy.GetMessages(2)
-            self.fail('Exception in HotSpotsByArea_iaTools for Pro toolbox \n' + msg)
+            self.fail('Exception in HotSpotsByArea_iaTools toolbox \n' + msg)
 
         # TODO: Doesn't seem to test anything
         self.assertTrue(arcpy.Exists(outputWorkspace))

--- a/utils/test/incident_analysis_tests/IncidentDensityTestCase.py
+++ b/utils/test/incident_analysis_tests/IncidentDensityTestCase.py
@@ -101,7 +101,7 @@ class IncidentDensityTestCase(unittest.TestCase):
             arcpy.IncidentDensity_iaTools(self.inputPointFeatures, self.inputBoundaryFeatures, outputDensity)
         except:
             msg = arcpy.GetMessages(2)
-            self.fail('Exception in IncidentDensity_iaTools for Pro toolbox \n' + msg)
+            self.fail('Exception in IncidentDensity_iaTools toolbox \n' + msg)
 
         self.assertTrue(arcpy.Exists(outputDensity))
 

--- a/utils/test/incident_analysis_tests/IncidentHotSpotsTestCase.py
+++ b/utils/test/incident_analysis_tests/IncidentHotSpotsTestCase.py
@@ -101,7 +101,7 @@ class IncidentHotSpotsTestCase(unittest.TestCase):
             arcpy.IncidentHotSpots_iaTools(self.inputPointFeatures, self.inputBoundaryFeatures, outputFeatures)
         except:
             msg = arcpy.GetMessages(2)
-            self.fail('Exception in IncidentHotSpots_iaTools for Pro toolbox \n' + msg)
+            self.fail('Exception in IncidentHotSpots_iaTools toolbox \n' + msg)
 
         result = arcpy.GetCount_management(outputFeatures)
         featureCount = int(result.getOutput(0))


### PR DESCRIPTION
Address 

`1.` Crash when running test drivers in  Pro 1.0-1.4.1 :

`...SyntaxError: invalid or missing encoding declaration for '...XXXX.tbx'  ` when running test driver in Pro 1.0-1.4.1 

Note: seems to have been fixed in Pro 2.0/python 3.5.3 [with this fix](https://bugs.python.org/issue25388)

`2.` Badly formatted output ( "`/n`") when test drivers run with Pro 

`3.` Stray "pro" in comments/prints


