### PR TITLE
Update paths to layer files in Clearing Op scripts

### DIFF
--- a/clearing_operations/scripts/CanvasAreaGRG.py
+++ b/clearing_operations/scripts/CanvasAreaGRG.py
@@ -344,7 +344,8 @@ def main():
             layer = arcpy.mapping.Layer(targetLayerName)            
             
             # get the symbology from the NumberedStructures.lyr
-            layerFilePath = os.path.join(os.getcwd(),"data\Layers\GRG.lyr")
+            #layerFilePath = os.path.join(os.getcwd(),"data\Layers\GRG.lyr")
+            layerFilePath = os.path.join(os.path.dirname(os.path.dirname(__file__)),"layers\GRG.lyr")
             
             # apply the symbology to the layer
             arcpy.ApplySymbologyFromLayer_management(layer, layerFilePath)

--- a/clearing_operations/scripts/NumberFeatures.py
+++ b/clearing_operations/scripts/NumberFeatures.py
@@ -248,7 +248,8 @@ def main():
             layer = arcpy.mapping.Layer(targetLayerName)            
             
             # get the symbology from the NumberedStructures.lyr
-            layerFilePath = os.path.join(os.getcwd(),r"data\Layers\NumberedStructures.lyr")
+            #layerFilePath = os.path.join(os.getcwd(),r"data\Layers\NumberedStructures.lyr")
+            layerFilePath = os.path.join(os.path.dirname(os.path.dirname(__file__)),"layers\NumberedStructures.lyr")
             
             # apply the symbology to the layer
             arcpy.ApplySymbologyFromLayer_management(layer, layerFilePath)

--- a/clearing_operations/scripts/PointTargetGRG.py
+++ b/clearing_operations/scripts/PointTargetGRG.py
@@ -557,7 +557,8 @@ def main():
             layer = arcpy.mapping.Layer(targetLayerName)            
             
             # get the symbology from the NumberedStructures.lyr
-            layerFilePath = os.path.join(os.getcwd(),"data\Layers\GRG.lyr")
+            #layerFilePath = os.path.join(os.getcwd(),"data\Layers\GRG.lyr")
+            layerFilePath = os.path.join(os.path.dirname(os.path.dirname(__file__)),"layers\GRG.lyr")
             
             # apply the symbology to the layer
             arcpy.ApplySymbologyFromLayer_management(layer, layerFilePath)


### PR DESCRIPTION
Updated paths to layer files in ArcMap section of Clearing Op scripts.

## Description
Calling files from __file__ instead of os.cwd().

## Related Issue

## Motivation and Context
Currently the relative location of LYR file to path is not correct. 

## How Has This Been Tested?
Manual test in Desktop 10.5 and Pro 2.0

## Screenshots (if appropriate):

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
