### PR TITLE
Updates to Number Features Script

### DIFF
--- a/clearing_operations/scripts/NumberFeatures.py
+++ b/clearing_operations/scripts/NumberFeatures.py
@@ -231,37 +231,37 @@ def main():
 
         # Get and label the output feature
         if appEnvironment == "ARCGIS_PRO":
-
+            
             #params = arcpy.GetParameterInfo()
             ##get the symbology from the NumberedStructures.lyr
             #scriptPath = sys.path[0]
             #arcpy.AddMessage(scriptPath)
-            #layerFilePath = os.path.join(scriptPath,r"commondata\userdata\NumberedStructures.lyrx")
+            #layerFilePath = os.path.join(scriptPath,r"commondata\userdata\NumberedStructures.lyrx")            
             #params[3].symbology = layerFilePath
             #arcpy.AddMessage("Applying Symbology from {0}".format(layerFilePath))
-
+            
             arcpy.AddMessage("Applying symbology on the script tool based on best practice")
-
+           
         elif appEnvironment == "ARCMAP":
             #arcpy.AddMessage("Adding features to map (" + str(targetLayerName) + ")...")
-
+            
             #arcpy.MakeFeatureLayer_management(outputFeatureClass, targetLayerName)
-
+            
             # create a layer object
-            #layer = arcpy.mapping.Layer(targetLayerName)
-
+            #layer = arcpy.mapping.Layer(targetLayerName)            
+            
             # get the symbology from the NumberedStructures.lyr
             #layerFilePath = os.path.join(os.getcwd(),r"data\Layers\NumberedStructures.lyr")
             #layerFilePath = os.path.join(os.path.dirname(os.path.dirname(__file__)),r"layers\NumberedStructures.lyr")
-
+            
             # apply the symbology to the layer
             #arcpy.ApplySymbologyFromLayer_management(layer, layerFilePath)
-
+            
             # add layer to map
             #arcpy.mapping.AddLayer(df, layer, "AUTO_ARRANGE")
-
+            
             # find the target layer in the map
-            #mapLyr = arcpy.mapping.ListLayers(mxd, targetLayerName)[0]
+            #mapLyr = arcpy.mapping.ListLayers(mxd, targetLayerName)[0]  
 
             #arcpy.AddMessage("Labeling output features (" + str(targetLayerName) + ")...")
             # Work around needed as ApplySymbologyFromLayer_management does not honour labels
@@ -275,7 +275,7 @@ def main():
             arcpy.AddMessage("Non-map application, skipping labeling...")
 
 
-        arcpy.SetParameter(3, outputFeatureClass)
+        #arcpy.SetParameter(3, outputFeatureClass)
 
 
     except arcpy.ExecuteError:

--- a/clearing_operations/scripts/NumberFeatures.py
+++ b/clearing_operations/scripts/NumberFeatures.py
@@ -231,37 +231,37 @@ def main():
 
         # Get and label the output feature
         if appEnvironment == "ARCGIS_PRO":
-            
+
             #params = arcpy.GetParameterInfo()
             ##get the symbology from the NumberedStructures.lyr
             #scriptPath = sys.path[0]
             #arcpy.AddMessage(scriptPath)
-            #layerFilePath = os.path.join(scriptPath,r"commondata\userdata\NumberedStructures.lyrx")            
+            #layerFilePath = os.path.join(scriptPath,r"commondata\userdata\NumberedStructures.lyrx")
             #params[3].symbology = layerFilePath
             #arcpy.AddMessage("Applying Symbology from {0}".format(layerFilePath))
-            
+
             arcpy.AddMessage("Applying symbology on the script tool based on best practice")
-           
+
         elif appEnvironment == "ARCMAP":
             #arcpy.AddMessage("Adding features to map (" + str(targetLayerName) + ")...")
-            
+
             #arcpy.MakeFeatureLayer_management(outputFeatureClass, targetLayerName)
-            
+
             # create a layer object
-            #layer = arcpy.mapping.Layer(targetLayerName)            
-            
+            #layer = arcpy.mapping.Layer(targetLayerName)
+
             # get the symbology from the NumberedStructures.lyr
             #layerFilePath = os.path.join(os.getcwd(),r"data\Layers\NumberedStructures.lyr")
             #layerFilePath = os.path.join(os.path.dirname(os.path.dirname(__file__)),r"layers\NumberedStructures.lyr")
-            
+
             # apply the symbology to the layer
             #arcpy.ApplySymbologyFromLayer_management(layer, layerFilePath)
-            
+
             # add layer to map
             #arcpy.mapping.AddLayer(df, layer, "AUTO_ARRANGE")
-            
+
             # find the target layer in the map
-            #mapLyr = arcpy.mapping.ListLayers(mxd, targetLayerName)[0]  
+            #mapLyr = arcpy.mapping.ListLayers(mxd, targetLayerName)[0]
 
             #arcpy.AddMessage("Labeling output features (" + str(targetLayerName) + ")...")
             # Work around needed as ApplySymbologyFromLayer_management does not honour labels
@@ -275,7 +275,7 @@ def main():
             arcpy.AddMessage("Non-map application, skipping labeling...")
 
 
-        #arcpy.SetParameter(3, outputFeatureClass)
+        arcpy.SetParameter(3, outputFeatureClass)
 
 
     except arcpy.ExecuteError:

--- a/clearing_operations/scripts/NumberFeatures.py
+++ b/clearing_operations/scripts/NumberFeatures.py
@@ -275,7 +275,7 @@ def main():
             arcpy.AddMessage("Non-map application, skipping labeling...")
 
 
-        #arcpy.SetParameter(3, outputFeatureClass)
+        arcpy.SetParameter(3, outputFeatureClass)
 
 
     except arcpy.ExecuteError:

--- a/clearing_operations/scripts/NumberFeatures.py
+++ b/clearing_operations/scripts/NumberFeatures.py
@@ -202,8 +202,11 @@ def main():
         targetLayerName = ""
         if (overwriteFC):
             arcpy.AddMessage("Copying the features to the input, and then deleting the temporary feature class")
-            desc = arcpy.Describe(pointFeatureName)
-            overwriteFC = os.path.join(os.path.sep, desc.path, pointFeatureName)
+            desc = arcpy.Describe(pointFeatures)
+            if hasattr(desc, "layer"):
+              overwriteFC = desc.layer.catalogPath
+            else:
+              overwriteFC = desc.catalogPath
             fields = (numberingField, "SHAPE@")
             overwriteCursor = arcpy.da.UpdateCursor(overwriteFC, fields)
             for overwriteRow in overwriteCursor:
@@ -272,7 +275,7 @@ def main():
             arcpy.AddMessage("Non-map application, skipping labeling...")
 
 
-        arcpy.SetParameter(3, outputFeatureClass)
+        #arcpy.SetParameter(3, outputFeatureClass)
 
 
     except arcpy.ExecuteError:


### PR DESCRIPTION
It looks like the number features tool is trying to use the layer name
within the table of contents as the path name to the underlying feature
class which is not always going to be the same, the script needs to use
the underlying feature class path

changed lines 205 & 206:
```
desc = arcpy.Describe(pointFeatureName)
overwriteFC = os.path.join(os.path.sep, desc.path, pointFeatureName)
```
with:
```
desc = arcpy.Describe(pointFeatures)
if hasattr(desc, "layer"):
  overwriteFC = desc.layer.catalogPath
else:
  overwriteFC = desc.catalogPath
```
also there was an issue on line 275:

` arcpy.SetParameter(3, outputFeatureClass) `

the outputFeatureClass has been deleted on line 215 if overwriting an existing feature class:

` arcpy.Delete_management(outputFeatureClass) `

I have just commented this out for now
