### PR TITLE
Change polar region message to warning #625

### DIFF
--- a/clearing_operations/scripts/RefGrid.py
+++ b/clearing_operations/scripts/RefGrid.py
@@ -89,7 +89,7 @@ class ReferenceGrid(object):
       outsideSouthPolar = southPoly.disjoint(inputFeature.projectAs(sr))
       
       if(not outsideNorthPolar or not outsideSouthPolar):
-        arcpy.AddMessage("The GRG extent is within a polar region." + 
+        arcpy.AddWarning("The GRG extent is within a polar region." + 
           " Cells that fall within the polar region will not be created.")
 
     out_features = out_features.value


### PR DESCRIPTION
Due to feedback at the sprint review meeting I have changed the polar region message to a warning so it is more obvious to the user